### PR TITLE
adding coordinates in standard response of get_statsector endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -145,6 +145,8 @@ async def get_statsector(
         first_sector_result = sector_results.iloc[0]
 
         response = {
+            "lat": lat,
+            "lon": lon,
             "sector_id": first_sector_result["cd_sector"],
             "sector_name": first_sector_result["tx_sector_descr_nl"],
         }


### PR DESCRIPTION
If a request is made with just the address, this address is first mapped to coordinates and those coordinates then lead to a statsector identification.

However, if a user is interested in both, she currently has no access to the coordinate information as it is not included in the response.

The current workaround is making two request: `lookup_address` (to get coords) and `get_statsector` (with those coords, to get statsector id). This can be optimized by just returning lat and lon by default in the response of `get_statsector`. 

Two downsides: 
1) Sometimes, the response contains information the user submitted themselves (if they request a statsector for known coordinates). Seems harmless.
2) This is a change in the API. Clearly backwards compatible since it is purely an extension, so I'm hoping still straightforward? Unless some really shitty code is parsing our responses...